### PR TITLE
[VA-10] VanAnime所提供的api的logs补全，以及项目日志的Best Practice

### DIFF
--- a/src/libs/core/apiClient/apiClient.service.ts
+++ b/src/libs/core/apiClient/apiClient.service.ts
@@ -54,7 +54,7 @@ export class ApiClientService {
   private handleResponse = (response: AxiosResponse): AxiosResponse => {
     const ctx: Ctx = { ...this.ctx, functionContext: 'handleResponse' };
     this.logService.log(
-      `${response.status} --> ${response.config.method?.toUpperCase()} ${response.config.baseURL}${response.config.url}，RESPONSE <==> ${JSON.stringify(response.data, null, 2)}`,
+      `${response.status} --> ${response.config.method?.toUpperCase()} ${response.config.baseURL}${response.config.url}，RESPONSE <==> ${JSON.stringify(response.data)}`,
       ctx,
     );
     return response;

--- a/src/libs/core/log/log.service.ts
+++ b/src/libs/core/log/log.service.ts
@@ -68,7 +68,7 @@ export class LogService implements LoggerService {
     this.logger.info(message, ctx);
   }
 
-  logWithJSONData(message: any, data: unknown, ctx?: Ctx) {
+  logWithData(message: any, data: unknown, ctx?: Ctx) {
     this.logger.info(`${message} ${JSON.stringify(data)}`, ctx);
   }
 

--- a/src/libs/core/log/log.service.ts
+++ b/src/libs/core/log/log.service.ts
@@ -68,6 +68,19 @@ export class LogService implements LoggerService {
     this.logger.info(message, ctx);
   }
 
+  logWithJSONData(message: any, data: unknown, ctx?: Ctx) {
+    this.logger.info(`${message} ${JSON.stringify(data)}`, ctx);
+  }
+
+  logForRequest(path: string, payLoad: any, ctx?: Ctx) {
+    this.logger.info(`REQUEST RECEIVED <= ${JSON.stringify(path)}`, ctx);
+    this.logger.info(`PAYLOAD: ${JSON.stringify(payLoad)}`, ctx);
+  }
+
+  logForResponse(message: any, ctx?: Ctx) {
+    this.logger.info(`RESPONSE SENT => ${JSON.stringify(message)}`, ctx);
+  }
+
   error(message: string, ctx?: Ctx, trace?: string) {
     this.logger.error(`${message} - ${trace}`, ctx);
   }

--- a/src/libs/core/log/log.service.ts
+++ b/src/libs/core/log/log.service.ts
@@ -77,8 +77,8 @@ export class LogService implements LoggerService {
     this.logger.info(`PAYLOAD: ${JSON.stringify(payLoad)}`, ctx);
   }
 
-  logForResponse(message: any, ctx?: Ctx) {
-    this.logger.info(`RESPONSE SENT => ${JSON.stringify(message)}`, ctx);
+  logForResponse(responseData: any, ctx?: Ctx) {
+    this.logger.info(`RESPONSE SENT => ${JSON.stringify(responseData)}`, ctx);
   }
 
   error(message: string, ctx?: Ctx, trace?: string) {

--- a/src/libs/sources/dmhy/dmhy.service.ts
+++ b/src/libs/sources/dmhy/dmhy.service.ts
@@ -33,7 +33,7 @@ export class DmhyService implements SourceServiceInterface<DMHYSearchContent> {
     try {
       const response = await fetchResources(fetch, fetchQuery);
       const resources = response.resources;
-      this.logService.logWithData(`Dmhy回报的搜索结果：`, fetchQuery, ctx);
+      this.logService.logWithData(`Dmhy回报的搜索结果：`, resources, ctx);
       return resources.map((resource) => {
         return {
           provider: resource.provider,

--- a/src/libs/sources/dmhy/dmhy.service.ts
+++ b/src/libs/sources/dmhy/dmhy.service.ts
@@ -28,11 +28,12 @@ export class DmhyService implements SourceServiceInterface<DMHYSearchContent> {
       pageSize: this.configService.get<number>('DMHY_PAGE_SIZE'),
     };
 
-    this.logService.log(fetchQuery);
+    this.logService.logWithJSONData(`在Dmhy中搜索：`, fetchQuery, ctx);
 
     try {
       const response = await fetchResources(fetch, fetchQuery);
       const resources = response.resources;
+      this.logService.logWithJSONData(`Dmhy回报的搜索结果：`, fetchQuery, ctx);
       return resources.map((resource) => {
         return {
           provider: resource.provider,

--- a/src/libs/sources/dmhy/dmhy.service.ts
+++ b/src/libs/sources/dmhy/dmhy.service.ts
@@ -28,12 +28,12 @@ export class DmhyService implements SourceServiceInterface<DMHYSearchContent> {
       pageSize: this.configService.get<number>('DMHY_PAGE_SIZE'),
     };
 
-    this.logService.logWithJSONData(`在Dmhy中搜索：`, fetchQuery, ctx);
+    this.logService.logWithData(`在Dmhy中搜索：`, fetchQuery, ctx);
 
     try {
       const response = await fetchResources(fetch, fetchQuery);
       const resources = response.resources;
-      this.logService.logWithJSONData(`Dmhy回报的搜索结果：`, fetchQuery, ctx);
+      this.logService.logWithData(`Dmhy回报的搜索结果：`, fetchQuery, ctx);
       return resources.map((resource) => {
         return {
           provider: resource.provider,

--- a/src/libs/utils/magnet/torrent-transformer/torrent-transformer.service.ts
+++ b/src/libs/utils/magnet/torrent-transformer/torrent-transformer.service.ts
@@ -37,6 +37,7 @@ export class TorrentTransformerService {
       const client = new this.Webtorrent();
 
       try {
+        this.logService.log(`开始解析磁力链接 ${magnet}`, ctx);
         client.add(magnet, { announce: this.trackerList }, (torrent) => {
           const filesList: MagnetFile[] = torrent.files?.map((file) => ({
             name: file.name,

--- a/src/libs/utils/qbittorrent/qbittorrent.service.ts
+++ b/src/libs/utils/qbittorrent/qbittorrent.service.ts
@@ -114,15 +114,31 @@ export class QbittorrentService implements OnModuleInit {
   }
 
   async submitNewTask(fileDetails: MagnetFileDetails) {
+    const ctx: Ctx = { ...this.ctx, functionContext: 'submitNewTask' };
     const { filesList, torrentName, infoHash } = fileDetails;
+    this.logService.logWithJSONData(
+      '开始添加新Torrent，infoHash为：',
+      fileDetails.infoHash,
+      ctx,
+    );
     const addResult = await this.addTorrent(torrentName).then();
     // todo 考虑到实际服务器性能和意外情况，建议从硬等待改为短轮询
     await this.delay(3000);
 
     if (addResult) {
+      this.logService.logWithJSONData(
+        '添加Torrent完成，开始获取torrent内容，infoHash为：',
+        fileDetails.infoHash,
+        ctx,
+      );
       const torrentContents = await this.getTorrentContents(infoHash);
 
       if (torrentContents) {
+        this.logService.logWithJSONData(
+          '获取torrent内容完成，开始选择需要下载的文件，infoHash为：',
+          fileDetails.infoHash,
+          ctx,
+        );
         const changePrioResult = await this.changeContentPriority(
           infoHash,
           filesList,
@@ -130,15 +146,29 @@ export class QbittorrentService implements OnModuleInit {
         );
 
         if (changePrioResult) {
+          this.logService.logWithJSONData(
+            '准备工作皆已完成，开始恢复下载，infoHash为：',
+            fileDetails.infoHash,
+            ctx,
+          );
           const resumeResult = await this.resumeQBTask(infoHash);
 
           if (resumeResult) {
+            this.logService.logWithJSONData(
+              'Task添加完成，infoHash为：',
+              fileDetails.infoHash,
+              ctx,
+            );
             return true;
           }
         }
       }
     }
-
+    this.logService.logWithJSONData(
+      'Task添加失败，infoHash为：',
+      fileDetails.infoHash,
+      ctx,
+    );
     return false;
   }
 

--- a/src/libs/utils/qbittorrent/qbittorrent.service.ts
+++ b/src/libs/utils/qbittorrent/qbittorrent.service.ts
@@ -147,7 +147,7 @@ export class QbittorrentService implements OnModuleInit {
 
         if (changePrioResult) {
           this.logService.logWithData(
-            '准备工作皆已完成，开始恢复下载，infoHash为：',
+            '下载任务优先级配置完毕， 等待恢复下载，infoHash为：',
             fileDetails.infoHash,
             ctx,
           );

--- a/src/libs/utils/qbittorrent/qbittorrent.service.ts
+++ b/src/libs/utils/qbittorrent/qbittorrent.service.ts
@@ -116,7 +116,7 @@ export class QbittorrentService implements OnModuleInit {
   async submitNewTask(fileDetails: MagnetFileDetails) {
     const ctx: Ctx = { ...this.ctx, functionContext: 'submitNewTask' };
     const { filesList, torrentName, infoHash } = fileDetails;
-    this.logService.logWithJSONData(
+    this.logService.logWithData(
       '开始添加新Torrent，infoHash为：',
       fileDetails.infoHash,
       ctx,
@@ -126,7 +126,7 @@ export class QbittorrentService implements OnModuleInit {
     await this.delay(3000);
 
     if (addResult) {
-      this.logService.logWithJSONData(
+      this.logService.logWithData(
         '添加Torrent完成，开始获取torrent内容，infoHash为：',
         fileDetails.infoHash,
         ctx,
@@ -134,7 +134,7 @@ export class QbittorrentService implements OnModuleInit {
       const torrentContents = await this.getTorrentContents(infoHash);
 
       if (torrentContents) {
-        this.logService.logWithJSONData(
+        this.logService.logWithData(
           '获取torrent内容完成，开始选择需要下载的文件，infoHash为：',
           fileDetails.infoHash,
           ctx,
@@ -146,7 +146,7 @@ export class QbittorrentService implements OnModuleInit {
         );
 
         if (changePrioResult) {
-          this.logService.logWithJSONData(
+          this.logService.logWithData(
             '准备工作皆已完成，开始恢复下载，infoHash为：',
             fileDetails.infoHash,
             ctx,
@@ -154,7 +154,7 @@ export class QbittorrentService implements OnModuleInit {
           const resumeResult = await this.resumeQBTask(infoHash);
 
           if (resumeResult) {
-            this.logService.logWithJSONData(
+            this.logService.logWithData(
               'Task添加完成，infoHash为：',
               fileDetails.infoHash,
               ctx,
@@ -164,7 +164,7 @@ export class QbittorrentService implements OnModuleInit {
         }
       }
     }
-    this.logService.logWithJSONData(
+    this.logService.logWithData(
       'Task添加失败，infoHash为：',
       fileDetails.infoHash,
       ctx,

--- a/src/modules/downloader/magnet/magnet.controller.ts
+++ b/src/modules/downloader/magnet/magnet.controller.ts
@@ -3,18 +3,30 @@ import { MagnetService } from './magnet.service';
 import { AddParamDTO } from './dto/magnet.add.dto';
 import { Response } from 'express';
 import { MagnetSubmitDto } from './dto/magnet.submit.dto';
+import { LogService } from 'src/libs/core/log/log.service';
+import { Ctx } from 'src/libs/modal/ctx/Ctx';
 
 @Controller('magnet')
 export class MagnetController {
-  constructor(private readonly magnetService: MagnetService) {}
+  private readonly ctx: Ctx = {
+    serviceContext: 'MagnetController',
+  };
+
+  constructor(
+    private readonly magnetService: MagnetService,
+    private readonly logService: LogService,
+  ) {}
 
   @Post('parse')
   async parseMagnet(
     @Body() data: AddParamDTO,
     @Res() res: Response,
   ): Promise<void> {
+    const ctx: Ctx = { ...this.ctx, functionContext: 'parseMagnet' };
+    this.logService.logForRequest('/magnet/parse', data, ctx);
     const response = await this.magnetService.parseMagnet(data.magnet);
     res.status(200).json(response);
+    this.logService.logForResponse(response, ctx);
   }
 
   @Post('submit')
@@ -22,7 +34,10 @@ export class MagnetController {
     @Body() data: MagnetSubmitDto,
     @Res() res: Response,
   ): Promise<void> {
+    const ctx: Ctx = { ...this.ctx, functionContext: 'submitNewTask' };
+    this.logService.logForRequest('/magnet/submit', data, ctx);
     const response = await this.magnetService.submitNewTask(data);
     res.status(response.statusCode).json(response);
+    this.logService.logForResponse(response, ctx);
   }
 }

--- a/src/modules/downloader/magnet/magnet.service.ts
+++ b/src/modules/downloader/magnet/magnet.service.ts
@@ -7,17 +7,26 @@ import { HttpStatusCode } from 'axios';
 import { ResponseBase } from '../../../libs/dto/response-base.dto';
 import { MagnetSubmitDto } from './dto/magnet.submit.dto';
 import { StoreService } from '../../../libs/core/store/store.service';
+import { LogService } from 'src/libs/core/log/log.service';
+import { Ctx } from 'src/libs/modal/ctx/Ctx';
 
 @Injectable()
 export class MagnetService {
+  private readonly ctx: Ctx = {
+    serviceContext: 'MagnetService',
+  };
+
   constructor(
     private readonly qbService: QbittorrentService,
     private readonly torrentTransformService: TorrentTransformerService,
     private readonly storeService: StoreService,
+    private readonly logService: LogService,
   ) {}
 
   async parseMagnet(magnet: string) {
+    const ctx: Ctx = { ...this.ctx, functionContext: 'parseMagnet' };
     const results = await this.torrentTransformService.parseMagnet(magnet);
+    this.logService.logWithJSONData(`解析完成，结果为:`, results, ctx);
     const response = new MagnetParseResponseDto(
       HttpStatusCode.Ok,
       true,
@@ -27,7 +36,10 @@ export class MagnetService {
   }
 
   async submitNewTask(data: MagnetSubmitDto) {
-    if (this.storeService.findTask(data.details.infoHash)) {
+    const ctx: Ctx = { ...this.ctx, functionContext: 'submitNewTask' };
+    const infoHash = data.details.infoHash;
+    if (this.storeService.findTask(infoHash)) {
+      this.logService.warn(`在数据库中发现相同的infoHash：${infoHash}`, ctx);
       const response = new ResponseBase(
         HttpStatusCode.Ok,
         false,
@@ -39,6 +51,11 @@ export class MagnetService {
     const result = await this.qbService.submitNewTask(data.details);
 
     if (result) {
+      this.logService.logWithJSONData(
+        `Task提交成功，添加该记录，infoHash为：`,
+        infoHash,
+        ctx,
+      );
       this.storeService.addNewRecord(
         data.details.torrentName,
         data.originMagnet,

--- a/src/modules/downloader/magnet/magnet.service.ts
+++ b/src/modules/downloader/magnet/magnet.service.ts
@@ -26,7 +26,11 @@ export class MagnetService {
   async parseMagnet(magnet: string) {
     const ctx: Ctx = { ...this.ctx, functionContext: 'parseMagnet' };
     const results = await this.torrentTransformService.parseMagnet(magnet);
-    this.logService.logWithData(`解析完成，结果为:`, results, ctx);
+    this.logService.logWithData(
+      `磁力链接/Magnet解析完成，结果为:`,
+      results,
+      ctx,
+    );
     const response = new MagnetParseResponseDto(
       HttpStatusCode.Ok,
       true,

--- a/src/modules/downloader/magnet/magnet.service.ts
+++ b/src/modules/downloader/magnet/magnet.service.ts
@@ -26,7 +26,7 @@ export class MagnetService {
   async parseMagnet(magnet: string) {
     const ctx: Ctx = { ...this.ctx, functionContext: 'parseMagnet' };
     const results = await this.torrentTransformService.parseMagnet(magnet);
-    this.logService.logWithJSONData(`解析完成，结果为:`, results, ctx);
+    this.logService.logWithData(`解析完成，结果为:`, results, ctx);
     const response = new MagnetParseResponseDto(
       HttpStatusCode.Ok,
       true,
@@ -51,7 +51,7 @@ export class MagnetService {
     const result = await this.qbService.submitNewTask(data.details);
 
     if (result) {
-      this.logService.logWithJSONData(
+      this.logService.logWithData(
         `Task提交成功，添加该记录，infoHash为：`,
         infoHash,
         ctx,

--- a/src/modules/query/query.controller.ts
+++ b/src/modules/query/query.controller.ts
@@ -4,16 +4,27 @@ import { Response } from 'express';
 import { SearchParamDTO } from './dto/query.search.dto';
 import { QueryBangumiCheckDto } from './dto/query.bangumi-check.dto';
 import { HttpStatusCode } from 'axios';
+import { Ctx } from 'src/libs/modal/ctx/Ctx';
+import { LogService } from 'src/libs/core/log/log.service';
 
 @Controller('query')
 export class QueryController {
-  constructor(private readonly queryService: QueryService) {}
+  private readonly ctx: Ctx = {
+    serviceContext: 'QueryController',
+  };
+  constructor(
+    private readonly queryService: QueryService,
+    private readonly logService: LogService,
+  ) {}
 
   @Post()
   async queryFromSource(
     @Body() data: SearchParamDTO,
     @Res() res: Response,
   ): Promise<void> {
+    const ctx: Ctx = { ...this.ctx, functionContext: 'queryFromSource' };
+    // TODO：非正确返回时候的code管理
+    this.logService.logForRequest('/query', data, ctx);
     const { source, searchContent } = data;
     if (!(await this.queryService.bangumiCheck(searchContent))) {
       const results = new QueryBangumiCheckDto(
@@ -22,10 +33,11 @@ export class QueryController {
         '搜索目标为本季新番，不支持该搜索。',
       );
       res.status(200).json(results);
+      this.logService.logForResponse(results, ctx);
       return;
     }
     const results = await this.queryService.search(source, searchContent);
-
+    this.logService.logForResponse(results, ctx);
     res.status(200).json(results);
   }
 }

--- a/src/modules/query/query.service.ts
+++ b/src/modules/query/query.service.ts
@@ -57,11 +57,7 @@ export class QueryService {
       Array.isArray(cacheList) &&
       cacheList.every((item) => typeof item === 'string')
     ) {
-      this.logService.logWithJSONData(
-        `检查该番剧是否为新番`,
-        searchContent,
-        ctx,
-      );
+      this.logService.logWithData(`检查该番剧是否为新番`, searchContent, ctx);
       const fuseList = new Fuse(cacheList, { threshold: 0.4 });
       const checkResult = this.isCacheHitWithFuzzySearch(
         fuseList,

--- a/src/modules/query/query.service.ts
+++ b/src/modules/query/query.service.ts
@@ -7,31 +7,48 @@ import { fetchCalenderAPI } from '../../libs/utils/bangumi-api/fetchCalender';
 import { CACHE_MANAGER, Cache } from '@nestjs/cache-manager';
 import Fuse from 'fuse.js';
 import { CalenderGetException } from '../../libs/exceptions/query/CalenderGetException';
+import { Ctx } from 'src/libs/modal/ctx/Ctx';
+import { LogService } from 'src/libs/core/log/log.service';
 
 @Injectable()
 export class QueryService {
+  private readonly ctx: Ctx = {
+    serviceContext: 'QueryService',
+  };
+
   constructor(
     private readonly sourcesService: SourcesService,
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
+    private readonly logService: LogService,
   ) {}
 
   async search(
     source: string,
     searchContent: DMHYSearchContent,
   ): Promise<QueryResponseDto> {
+    //TODO: 缺少source不存在的错误管理，但在前端会固定提供source的情况下一般不会出错
+    const ctx: Ctx = { ...this.ctx, functionContext: 'search' };
+
+    this.logService.log(`使用了${source}源进行搜索`, ctx);
     const searchService = this.sourcesService.getService(source);
 
     const res = await searchService?.search(searchContent);
     const response = new QueryResponseDto(HttpStatusCode.Ok, true, res, source);
-
     return response;
   }
 
   async bangumiCheck(searchContent: DMHYSearchContent): Promise<boolean> {
+    // TODO：重定义bangumiCheck的function命名。以更符合其功能
+    const ctx: Ctx = { ...this.ctx, functionContext: 'bangumiCheck' };
     const bangumiListKey = 'bangumiList';
     let cacheList = await this.cacheManager.get(bangumiListKey);
 
     if (!cacheList) {
+      //fetchCalenderAPI() 返回当季所有新番的list，并储存在cache中
+      this.logService.log(
+        `未发现任何新番列表信息缓存，访问源以获取最新的新番列表`,
+        ctx,
+      );
       cacheList = await fetchCalenderAPI();
       await this.cacheManager.set(bangumiListKey, cacheList, 600 * 60 * 1000);
     }
@@ -40,8 +57,22 @@ export class QueryService {
       Array.isArray(cacheList) &&
       cacheList.every((item) => typeof item === 'string')
     ) {
+      this.logService.logWithJSONData(
+        `检查该番剧是否为新番`,
+        searchContent,
+        ctx,
+      );
       const fuseList = new Fuse(cacheList, { threshold: 0.4 });
-      const checkResult = this.fuzzySearch(fuseList, searchContent);
+      const checkResult = this.isCacheHitWithFuzzySearch(
+        fuseList,
+        searchContent,
+      );
+
+      if (checkResult) {
+        this.logService.log(`此番不是新番`, ctx);
+      } else {
+        this.logService.warn(`Cache hit！此番是新番`, ctx);
+      }
 
       return checkResult;
     } else {
@@ -49,12 +80,12 @@ export class QueryService {
     }
   }
 
-  private fuzzySearch(
+  private isCacheHitWithFuzzySearch(
     fuseList: Fuse<string>,
     searchContent: DMHYSearchContent,
   ): boolean {
     const { search, include, keywords } = searchContent;
-
+    //这里的逻辑为 false意为发现cache存在
     if (Array.isArray(search) && search.length >= 1) {
       for (const key of search) {
         if (fuseList.search(key).length !== 0) return false;


### PR DESCRIPTION
## What problem / related problems are you solving? What approach did you choose and why? / 为什么会有这个PR? 这个PR想解决什么问题？你怎样实现的，为什么？


Ticket: https://alengs6141.atlassian.net/browse/VA-10

这个PR填补了VanAnime现有api服务的日志空缺，主要包括的api有：
`/query`, `/magnet/parse`, `/magnet/submit` 

对应api的controller，service皆在workflow的关键点补全了对应日志，以便可以通过日志追踪整个工作流。

LogService功能增强，新增如下方法：
`logWithData(message: any, data: unknown, ctx?: Ctx)`: 用于打印需要在结尾附带任何数据的日志。
`logForRequest(path: string, payLoad: any, ctx?: Ctx)`: 专门用于打印request相关的日志，`path`为request路径，`payLoad` 为接收到的request data。
`logForResponse(responseData: any, ctx?: Ctx)`:专门用于打印response相关的日志，`responseData` 为响应需要发出的data。

## Any open questions? What should reviewers focus on? / 其他开发者应该着重检查什么部分？
**这篇PR同时定义了VanAnime, 或者说Valiya所有项目的日志Best Practice。**
VanAnime日志需要达到的终极目标为能让服务器Host与开发者可以仅通过日志追踪所有服务器的行为，以方便后续维护与问题查询。
每一个workflow/feature都需要在关键节点的至少打印一条简单直白的日志用于描述该workflow经过并使用了这里的功能，以及什么样的结果。
每一个后续新增的 `Service`/`Controller` 等都需要在开头引入一个`Ctx`常数，这个常数将带有该`Service`/`Controller`的对应名称，例如：
```
private readonly ctx: Ctx = { serviceContext: 'QbittorrentService', };
```
在之后该`Service`/`Controller`的所有方法中，方法对应的`ctx`都可以通过这个全局`ctx`来直接生成。例如在该服务的`submitNewTask`中：
```
const ctx: Ctx = { ...this.ctx, functionContext: 'submitNewTask' };
```
这样在本方法中所有的`LogService`方法调用都可以直接输入这个`ctx`以传输上下文关系。

在`Controller`中，在接到请求，任何逻辑开始前，需要使用`logForRequest`打印对应的request path与输入参数，这样就能通过日志知道这个api workflow开始时的状态。同样在所有逻辑完成后，返回响应时，需要使用`logForResponse`将对应的response data打印出来以便于知道api workflow最后返回了什么。完整案例如下：

```
@Post('parse')
  async parseMagnet(
    @Body() data: AddParamDTO,
    @Res() res: Response,
  ): Promise<void> {
    const ctx: Ctx = { ...this.ctx, functionContext: 'parseMagnet' };
    this.logService.logForRequest('/magnet/parse', data, ctx);
    const response = await this.magnetService.parseMagnet(data.magnet);
    res.status(200).json(response);
    this.logService.logForResponse(response, ctx);
  }
```

打印日志需要保证feature/workflow中每个关键操作节点都能被反应在日志串中，同理，`submitNewTask`提供了一个很好的例子：
```
async submitNewTask(fileDetails: MagnetFileDetails) {
    const ctx: Ctx = { ...this.ctx, functionContext: 'submitNewTask' };
    const { filesList, torrentName, infoHash } = fileDetails;
    this.logService.logWithData(
      '开始添加新Torrent，infoHash为：',
      fileDetails.infoHash,
      ctx,
    );
    const addResult = await this.addTorrent(torrentName).then();
    // todo 考虑到实际服务器性能和意外情况，建议从硬等待改为短轮询
    await this.delay(3000);

    if (addResult) {
      this.logService.logWithData(
        '添加Torrent完成，开始获取torrent内容，infoHash为：',
        fileDetails.infoHash,
        ctx,
      );
      const torrentContents = await this.getTorrentContents(infoHash);

      if (torrentContents) {
        this.logService.logWithData(
          '获取torrent内容完成，开始选择需要下载的文件，infoHash为：',
          fileDetails.infoHash,
          ctx,
        );
        const changePrioResult = await this.changeContentPriority(
          infoHash,
          filesList,
          torrentContents,
        );

        if (changePrioResult) {
          this.logService.logWithData(
            '准备工作皆已完成，开始恢复下载，infoHash为：',
            fileDetails.infoHash,
            ctx,
          );
          const resumeResult = await this.resumeQBTask(infoHash);

          if (resumeResult) {
            this.logService.logWithData(
              'Task添加完成，infoHash为：',
              fileDetails.infoHash,
              ctx,
            );
            return true;
          }
        }
      }
    }
    this.logService.logWithData(
      'Task添加失败，infoHash为：',
      fileDetails.infoHash,
      ctx,
    );
    return false;
  }
```

可以看见这个方法包含了一个完整的工作流，其中包括复数的步骤且每一步都需要上一步打到一定条件时才能继续进行。日志打印就需要充分体现每一个步骤 和 其对应状态。以便后续问题检查。

## Testing / 测试证明

所有现有的api均通过了本地live test。
![AU$VLJ419G0EVHMD%W51XFJ](https://github.com/user-attachments/assets/e7b93e8d-9cd8-499b-add3-2da1be19034a)


## Before you deploy / 在提交前检查以下部分

- [x] This PR is safe to rollback. (If not please explain why) / 这个PR可以随时安全的被回滚
- [x] I tested this change. / 我测试了我的所有改动
- [x] I have performed a self-review of my code. / 我自己已经检查了其中的所有代码
- [x] I have linked (and updated) a relevant design document / 我将设计相关的文档link在了该PR中